### PR TITLE
Remove dead domains

### DIFF
--- a/sites.txt
+++ b/sites.txt
@@ -19,7 +19,6 @@
 ||winz.io$all
 ||replacemypolicyllc.com$all
 ||revivalfilm.com$all
-||dailyfucking.xyz$all
 ||1xbtc.io$all
 ||videocampaign.co$all
 ||taghaugh.com$all
@@ -36,7 +35,6 @@
 ||exness.com$all
 ||bitmagge.com$all
 ||gruposputaria.net$all
-||easy-claimer.shop$all
 ||bongacams.com$all
 ||brainbux.com$all
 ||drivereasy.com$all


### PR DESCRIPTION
This PR removes a few dead domains.
This is more of a nitpick, so I didn't change it in this PR, but you might want to replace `$all` with `^$all`, as `||example.com$all` also blocks `example.com.github.io`. This is a weird edge case, so it probably doesn't make much of a difference. 
Thanks.